### PR TITLE
Allow state option to be overridden

### DIFF
--- a/lib/passport-pinterest/strategy.js
+++ b/lib/passport-pinterest/strategy.js
@@ -50,7 +50,7 @@ function Strategy(options, verify) {
     options.authorizationURL = options.authorizationURL || 'https://api.pinterest.com/oauth/';
     options.tokenURL = options.tokenURL || 'https://api.pinterest.com/v1/oauth/token';
     options.scopeSeparator = ',';
-    options.state = true;
+    options.state = options.state || true;
     options.sessionKey = options.sessionKey || 'oauth2:pinterest';
 
     OAuth2Strategy.call(this, options, verify);


### PR DESCRIPTION
Small change to avoid overwriting the passed in state param.
