### PR TITLE
passing custom state param to pinterest

### DIFF
--- a/lib/passport-pinterest/strategy.js
+++ b/lib/passport-pinterest/strategy.js
@@ -67,14 +67,12 @@ function Strategy(options, verify) {
     validateStringOption('authorizationURL');
     validateStringOption('tokenURL');
     validateStringOption('scopeSeparator');
-    validateStringOption('state');
     validateStringOption('sessionKey');
     validateStringOption('profileURL');
 
     options.authorizationURL = options.authorizationURL || 'https://api.pinterest.com/oauth/';
     options.tokenURL = options.tokenURL || 'https://api.pinterest.com/v1/oauth/token';
     options.scopeSeparator = options.scopeSeparator || ',';
-    options.state = options.state || true;
     options.sessionKey = options.sessionKey || 'oauth2:pinterest';
 
     OAuth2Strategy.call(this, options, verify);


### PR DESCRIPTION
To pass custom state param to pinterest, removed state param from the code as `passport-oauth2` handles it. If there is any incoming custom state param then `passport-oauth2` passes it back to the user. See [Passport-oauth2](https://github.com/jaredhanson/passport-oauth2/blob/master/lib/strategy.js#L176)

Refer to issue [#3](https://github.com/analog-nico/passport-pinterest/issues/3) for more details.
